### PR TITLE
カートデザインの更新と数量制御の改善

### DIFF
--- a/app/components/CartItem.test.tsx
+++ b/app/components/CartItem.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import { CartItem as CartItemType } from "~/types/cartItem";
+
+import CartItem from "./CartItem";
+
+// モックデータ
+const mockItem: CartItemType = {
+  id: "1",
+  name: "テストアイテム",
+  price: 500,
+  quantity: 2,
+  // 画像プロパティが必要な場合は追加
+};
+
+// モック関数
+const mockUpdateQuantity = jest.fn();
+const mockRemoveItem = jest.fn();
+
+describe("CartItem コンポーネント", () => {
+  beforeEach(() => {
+    render(
+      <CartItem
+        item={mockItem}
+        updateQuantity={mockUpdateQuantity}
+        removeItem={mockRemoveItem}
+      />
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("アイテムの詳細が正しく表示される", () => {
+    expect(screen.getByText("テストアイテム")).toBeInTheDocument();
+    expect(screen.getByText(/単価: 500円 小計: 1000円/)).toBeInTheDocument();
+  });
+
+  test("増加ボタンクリックで数量が更新される", () => {
+    const incrementButton = screen.getByRole("button", { name: "+" });
+    fireEvent.click(incrementButton);
+    expect(mockUpdateQuantity).toHaveBeenCalledWith("1", 3);
+  });
+
+  test("減少ボタンクリックで数量が更新される", () => {
+    const decrementButton = screen.getByRole("button", { name: "-" });
+    fireEvent.click(decrementButton);
+    expect(mockUpdateQuantity).toHaveBeenCalledWith("1", 1);
+  });
+
+  test("数量が1の場合に減少ボタンを押してもマイナスにならない", () => {
+    // 既存のレンダリングをクリーンアップ
+    cleanup();
+
+    // 数量が1の場合のモックデータで独立したレンダリング
+    const mockItemWithMinQuantity: CartItemType = {
+      ...mockItem,
+      quantity: 1,
+    };
+    render(
+      <CartItem
+        item={mockItemWithMinQuantity}
+        updateQuantity={mockUpdateQuantity}
+        removeItem={mockRemoveItem}
+      />
+    );
+    const decrementButton = screen.getByRole("button", {
+      name: "-",
+      hidden: true,
+    });
+    expect(decrementButton).toHaveAttribute("disabled");
+    fireEvent.click(decrementButton);
+    expect(mockUpdateQuantity).not.toHaveBeenCalled();
+  });
+
+  test("削除ボタンクリックでアイテムが削除される", () => {
+    const deleteButton = screen.getByRole("button", { name: "削除" });
+    fireEvent.click(deleteButton);
+    expect(mockRemoveItem).toHaveBeenCalledWith("1");
+  });
+});

--- a/app/components/CartItem.tsx
+++ b/app/components/CartItem.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 
-import Button from "~/components/Button";
-import QuantityControl from "~/components/QuantityControl";
 import { CartItem as CartItemType } from "~/types/cartItem";
+
+import Button from "./Button";
+import QuantityControl from "./QuantityControl";
 
 interface CartItemProps {
   item: CartItemType;

--- a/app/routes/menu.$itemId.tsx
+++ b/app/routes/menu.$itemId.tsx
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 
 import Button from "~/components/Button";
 import LayoutConverter from "~/components/LayoutConverter";
+import QuantityControl from "~/components/QuantityControl";
 import { API_ENDPOINT, API_KEY } from "~/constants/api";
 import { CartItem } from "~/types/cartItem";
 import Item from "~/types/item";
@@ -48,23 +49,12 @@ export default function MenuItemRoute() {
               <label htmlFor="quantity" className="mr-2">
                 数量:
               </label>
-              <Button
-                variant="secondary"
-                size="small"
-                onClick={() => setQuantity(quantity - 1)}
-              >
-                -
-              </Button>
-              <span className="w-20 border rounded px-2 py-1 mx-2">
-                {quantity}
-              </span>
-              <Button
-                variant="secondary"
-                size="small"
-                onClick={() => setQuantity(quantity + 1)}
-              >
-                +
-              </Button>
+              <QuantityControl
+                quantity={quantity}
+                onIncrement={() => setQuantity(quantity + 1)}
+                onDecrement={() => setQuantity(quantity - 1)}
+                min={1}
+              />
             </div>
           </div>
           <div className="flex justify-center">
@@ -74,6 +64,7 @@ export default function MenuItemRoute() {
                 addToCart(item, quantity);
               }}
               className="mr-4"
+              disabled={quantity < 1}
             >
               カートに入れる
             </Button>


### PR DESCRIPTION
**PR概要**:  
このプルリクエストでは、カートのデザインを詳細に合わせ、数量がマイナスにならないようにする機能を実装しました。主な変更点は以下の通りです：
- app/routes/menu.$itemId.tsx に QuantityControl コンポーネントを導入し、数量の最小値を1に設定してマイナス値を防止。
- 「カートに入れる」ボタンを数量が1未満の場合に無効化。
- CartItem コンポーネントのテストを更新し、数量制御の動作を確認。

これらの変更により、ユーザー体験が向上し、カートの操作がより直感的になりました。レビューとマージをお願いします。

